### PR TITLE
Update default value of logfilename to use repr()

### DIFF
--- a/henry/.support_files/logging.conf
+++ b/henry/.support_files/logging.conf
@@ -41,31 +41,31 @@ propagate=0
 class=handlers.RotatingFileHandler
 level=DEBUG
 formatter=simpleFormatter
-args=('%(logfilename)s', 'a', 500000, 10)
+args=(%(logfilename)s, 'a', 500000, 10)
 
 [handler_fetcherHandler]
 class=handlers.RotatingFileHandler
 level=DEBUG
 formatter=simpleFormatter
-args=('%(logfilename)s', 'a', 500000, 10)
+args=(%(logfilename)s, 'a', 500000, 10)
 
 [handler_analyzeHandler]
 class=handlers.RotatingFileHandler
 level=DEBUG
 formatter=simpleFormatter
-args=('%(logfilename)s', 'a', 500000, 10)
+args=(%(logfilename)s, 'a', 500000, 10)
 
 [handler_apiHandler]
 class=handlers.RotatingFileHandler
 level=DEBUG
 formatter=simpleFormatter
-args=('%(logfilename)s', 'a', 500000, 10)
+args=(%(logfilename)s, 'a', 500000, 10)
 
 [handler_vacuumHandler]
 class=handlers.RotatingFileHandler
 level=DEBUG
 formatter=simpleFormatter
-args=('%(logfilename)s', 'a', 500000, 10)
+args=(%(logfilename)s, 'a', 500000, 10)
 
 [formatter_simpleFormatter]
 format: %(asctime)s.%(msecs)03d [%(levelname)s|%(name)s] :: %(message)s

--- a/henry/cli.py
+++ b/henry/cli.py
@@ -31,7 +31,7 @@ elif os.path.exists(LOGGING_LOG_PATH) and not os.path.isdir(LOGGING_LOG_PATH):
     sys.exit(1)
 LOGGING_LOG_PATH = os.path.join(LOGGING_LOG_PATH, 'henry.log')
 logging.config.fileConfig(LOGGING_CONFIG_PATH,
-                          defaults={'logfilename': LOGGING_LOG_PATH},
+                          defaults={'logfilename': repr(LOGGING_LOG_PATH)},
                           disable_existing_loggers=False)
 from .commands.analyze import Analyze
 from .commands.vacuum import Vacuum


### PR DESCRIPTION
Because the python logging module will do an eval() on the args parameter extra care must be taken to handle paths that may contain escape sequences. An import of the library failed on a windows machine where the path contains a folder called Users because on windows the separator is a backslash and the string became something like "c:\Users" which when passed as a default without using repr() caused the eval() to think this was a unicode escape sequence. The solution I have provided here wraps the default value passed in the dictionary with a repr() call and removes the surrounding single quotes in the logging.conf where that value is substituted into a tuple. The single quotes around the substitution marker are not needed any longer since repr() will generate them. 