### PR TITLE
account for changing of case on explore names

### DIFF
--- a/henry/commands/analyze.py
+++ b/henry/commands/analyze.py
@@ -95,7 +95,7 @@ class Analyze(fetcher.Fetcher):
                     "# Unused Fields": len(self._filter(field_stats)),
                     "Query Count": self.get_used_explores(
                         model=e.model_name, explore=e.name
-                    ).get(e.name, 0),
+                    ).get(e.name.lower(), 0),
                 }
             )
         return result

--- a/henry/modules/fetcher.py
+++ b/henry/modules/fetcher.py
@@ -183,7 +183,7 @@ class Fetcher:
         )
         _results: MutableSequence[Dict[str, int]] = json.loads(resp)
         results = {
-            cast(str, r["query.view"]): r["history.query_run_count"] for r in _results
+            cast(str, r["query.view"].lower()): r["history.query_run_count"] for r in _results
         }
         return results
 


### PR DESCRIPTION
In i__looker, Looker will track query.view with the case that it created with. This means if the case is changed away from the initial at any point, Henry will report the usage of the explore as 0, even if this is used extensively. 

Here are the steps to repro:

1. create New_Prd_ExplorE explore
2. run a couple queries
3. change explore name to new_prd_explore
4. run more queries
5. i__looker only registers all queries under  New_Prd_ExplorE
6. run henry analyze explore --model foo --explore new_prd_explore

henry returns 0, when in fact the result is >0.

This PR fixes this issue.