### PR TITLE
Use Henry via Python (in addition to cmd) and docs update (how to use save-to-file and its arg)

### DIFF
--- a/PYTHONAPI_DOCS.md
+++ b/PYTHONAPI_DOCS.md
@@ -53,6 +53,16 @@ h.looker.get_legacy_features(     h.looker.get_version(             h.looker.sec
 h.looker.get_model(               h.looker.git_connection_tests(    h.looker.session
 ```
 ```python
+>>> h.pulse.*
+h.pulse.bar                    h.pulse.get_query_stats(
+h.pulse.check_connections(     h.pulse.get_query_type_count(
+h.pulse.check_integrations(    h.pulse.get_slow_queries(
+h.pulse.check_legacy_features( h.pulse.looker
+h.pulse.check_query_stats(     h.pulse.postfix_default
+h.pulse.check_scheduled_plans( h.pulse.pulse_logger
+h.pulse.check_version(         h.pulse.run_all(
+```
+```python
 >>> h.analyzer.*
 h.analyzer.analyze(                 h.analyzer.get_explores(            h.analyzer.get_used_explore_fields( h.analyzer.test_git_connection(
 h.analyzer.analyze_logger           h.analyzer.get_models(              h.analyzer.get_used_explores(

--- a/PYTHONAPI_DOCS.md
+++ b/PYTHONAPI_DOCS.md
@@ -24,33 +24,33 @@ Henry's interface to Looker API.
  
 
 ```python
-creds = {
+config = {
     "client_id": "",
     "client_secret": "",
-    "host": "<HOST-URL>",
+    "host": "",
     "port": 19999,
     "timeout": 500
 }
 
 from henry.api import Henry
 
-h = Henry(**creds)
+h = Henry(**config)
 ```
 That's all. It provides access to the following:
 
 ```python
 >>> h.*
-h.analyze( h.analyzer h.args     h.looker   h.pulse    h.scanner  h.sdk      h.to_df(   h.vacuum(
+h.analyze( h.analyzer h.args     h.api   h.pulse    h.scanner  h.sdk      h.to_df(   h.vacuum(
 ```
 ```python
->>> h.looker.*
-h.looker.api_logger               h.looker.get_models(              h.looker.host                     h.looker.session_info
-h.looker.auth(                    h.looker.get_project(             h.looker.id                       h.looker.test_connection(
-h.looker.get_connections(         h.looker.get_project_files(       h.looker.port                     h.looker.timeout
-h.looker.get_explore(             h.looker.get_projects(            h.looker.run_git_connection_test( h.looker.update_session(
-h.looker.get_integrations(        h.looker.get_session(             h.looker.run_inline_query(
-h.looker.get_legacy_features(     h.looker.get_version(             h.looker.secret
-h.looker.get_model(               h.looker.git_connection_tests(    h.looker.session
+>>> h.api.*
+h.api.api_logger               h.api.get_models(              h.api.host                     h.api.session_info
+h.api.auth(                    h.api.get_project(             h.api.id                       h.api.test_connection(
+h.api.get_connections(         h.api.get_project_files(       h.api.port                     h.api.timeout
+h.api.get_explore(             h.api.get_projects(            h.api.run_git_connection_test( h.api.update_session(
+h.api.get_integrations(        h.api.get_session(             h.api.run_inline_query(
+h.api.get_legacy_features(     h.api.get_version(             h.api.secret
+h.api.get_model(               h.api.git_connection_tests(    h.api.session
 ```
 ```python
 >>> h.pulse.*
@@ -85,7 +85,7 @@ creds = {...}
 henry = Henry(**creds)
 
 # -- Looker api
-looker = henry.looker
+looker = henry.api
 
 projects = looker.get_projects()
 models = looker.get_models()

--- a/PYTHONAPI_DOCS.md
+++ b/PYTHONAPI_DOCS.md
@@ -1,0 +1,109 @@
+# Henry's Python API
+
+To
+
+- Get all projects
+- Get all models in a project
+- Get all, used, unused explores in a model
+- Get all, used, unused fields in an explore
+- ... etc 
+
+And
+
+- Analyze models
+- Analyze explores
+
+And
+
+- Vacuum models
+- Vacuum explores
+
+## Getting started
+
+Henry's interface to Looker API.
+ 
+
+```python
+creds = {
+    "client_id": "",
+    "client_secret": "",
+    "host": "<HOST-URL>",
+    "port": 19999,
+    "timeout": 500
+}
+
+from henry.api import Henry
+
+h = Henry(**creds)
+```
+That's all. It provides access to the following:
+
+```python
+>>> h.*
+h.analyze( h.analyzer h.args     h.looker   h.pulse    h.scanner  h.sdk      h.to_df(   h.vacuum(
+```
+```python
+>>> h.looker.*
+h.looker.api_logger               h.looker.get_models(              h.looker.host                     h.looker.session_info
+h.looker.auth(                    h.looker.get_project(             h.looker.id                       h.looker.test_connection(
+h.looker.get_connections(         h.looker.get_project_files(       h.looker.port                     h.looker.timeout
+h.looker.get_explore(             h.looker.get_projects(            h.looker.run_git_connection_test( h.looker.update_session(
+h.looker.get_integrations(        h.looker.get_session(             h.looker.run_inline_query(
+h.looker.get_legacy_features(     h.looker.get_version(             h.looker.secret
+h.looker.get_model(               h.looker.git_connection_tests(    h.looker.session
+```
+```python
+>>> h.analyzer.*
+h.analyzer.analyze(                 h.analyzer.get_explores(            h.analyzer.get_used_explore_fields( h.analyzer.test_git_connection(
+h.analyzer.analyze_logger           h.analyzer.get_models(              h.analyzer.get_used_explores(
+h.analyzer.fetch_logger             h.analyzer.get_project_files(       h.analyzer.get_used_models(
+h.analyzer.get_explore_fields(      h.analyzer.get_unused_explores(     h.analyzer.looker
+```
+```python
+>>> h.scanner.*
+h.scanner.fetch_logger             h.scanner.get_project_files(       h.scanner.get_used_models(         h.scanner.vacuum_logger
+h.scanner.get_explore_fields(      h.scanner.get_unused_explores(     h.scanner.looker
+h.scanner.get_explores(            h.scanner.get_used_explore_fields( h.scanner.test_git_connection(
+h.scanner.get_models(              h.scanner.get_used_explores(       h.scanner.vacuum(
+```
+
+## Example usage:
+
+```python
+from henry.api import Henry
+creds = {...}
+henry = Henry(**creds)
+
+# -- Looker api
+looker = henry.looker
+
+projects = looker.get_projects()
+models = looker.get_models()
+files = looker.get_project_files(project='name')
+
+# -- Analyze (numbers)
+analyzer = henry.analyzer
+# explores
+explores = analyzer.get_explores()
+used_explores = analyzer.get_used_explores()
+unused_explores = analyzer.get_unused_explores()
+# fields
+fields = analyzer.get_explore_fields(explore='name')
+used_fields = analyzer.get_used_explore_fields()
+# full reports
+analyze_explores = henry.analyze(which='explores', model='', explore='')
+analyze_models = henry.analyze(which='models')
+
+# -- Scan (names)
+scanner = henry.scanner
+# explores
+explores_ = scanner.get_explores()
+used_explores_ = scanner.get_used_explores()
+unused_explores_ = scanner.get_unused_explores()
+# fields
+fields_ = scanner.get_explore_fields()
+used_fields_ = scanner.get_used_explore_fields()
+# full reports
+vacuum_explores = henry.vacuum(which='explores', model='', explore='')
+vacuum_models = henry.vacuum(which='models')
+```

--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ By default, API calls have a timeout of 120 seconds. This can be overriden using
 
 #### Output to File
 
-If the `--save` flag is used the tool saves the results to your current working directory. Example usage:
+If the `--output <FILE-NAME>` flag is used the tool saves the results to your current working directory. Example usage:
 
-    $ henry vacuum models --save
+    $ henry vacuum models --output myfilename
 
-saves the results in _vacuum_models\_{date}\_{time}.csv_ in the current working directory.
+saves the results in _myfilename.csv_ in the current working directory.
 
 <a name="pulse_cmd"></a>
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Henry: A Looker Cleanup Tool
 
+> To use Henry in Python, see [Henry API docs](PYTHONAPI_DOCS.md).
+
 Henry is a command line tool that helps determine model bloat in your Looker instance and identify unused content in models and explores. It is meant to help developers cleanup models from unused explores and explores from unused joins and fields, as well as maintain a healthy and user-friendly instance.
 
 ## Table of Contents

--- a/henry/api.py
+++ b/henry/api.py
@@ -26,17 +26,12 @@ class Looker:
 
         return LookerApi(**kwargs)
 
-    def sdk(**kwargs):
-        """TODO connect to looker_sdk and/or interface"""
-        pass
-
 
 class Henry:
     def __init__(self, **creds):
         self.args = _DEFAULTS
         self.args.update(**creds)
 
-        self.sdk = Looker.sdk(**creds)  # looker_sdk interface to Looker
         self.api = Looker.henry_api(**creds)  # Henry interface to Looker
 
     def _update_args(self, **kwargs) -> dict:

--- a/henry/api.py
+++ b/henry/api.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import uuid
+from henry.modules.lookerapi import LookerApi
+from typing import List
+
+_DEFAULTS = {'plain': None,
+             'model': None,
+             'explore': None,
+             'min_queries': 0,
+             'timeframe': 90,
+             'limit': None,
+             'sortkey': None
+             }
+
+
+class Looker:
+    def api(**kwargs) -> LookerApi:
+        kwargs['id'] = kwargs.pop('client_id')
+        kwargs['secret'] = kwargs.pop('client_secret')
+        return LookerApi(**kwargs)
+
+    def sdk(**kwargs):
+        """TODO connect to looker_sdk and/or interface"""
+        pass
+
+
+class Henry:
+
+    def __init__(self, **creds):
+        self.args = _DEFAULTS
+        self.args.update(**creds)
+
+        self.sdk = Looker.sdk(**creds)  # looker_sdk interface
+        session_info: str = f'Henry v0.1.3: sid=#{uuid.uuid1()}'
+        creds.update(session_info=session_info)
+        self.looker = Looker.api(**creds)  # Henry interface
+
+    def __call__(self):
+        return self.looker
+
+    def _copy_args(self, **kwargs) -> dict:
+        _args = self.args.copy()
+        _args.update(**kwargs)
+        return _args
+
+    @property
+    def pulse(self):
+        from henry.commands.pulse import Pulse
+
+        return Pulse(self.looker)
+
+    @property
+    def analyzer(self):
+        from henry.commands.analyze import Analyze
+
+        return Analyze(self.looker)
+
+    def analyze(self, **kwargs):
+        kwargs.update(command='analyze')
+        _args = self._copy_args(**kwargs)
+
+        return self.analyzer.analyze(**_args)
+
+    @property
+    def scanner(self):
+        from henry.commands.vacuum import Vacuum
+
+        return Vacuum(self.looker)
+
+    def vacuum(self, **kwargs) -> List[dict]:
+        kwargs.update(command='vacuum')
+        _args = self._copy_args(**kwargs)
+
+        return self.scanner.vacuum(**_args)
+
+    def to_df(self, data, **kwargs):
+        import pandas as pd
+
+        return pd.DataFrame(data, **kwargs)


### PR DESCRIPTION
CHANGES:
- Use Henry programmatically (not only cmd)
- Update docs on how to use save-to-file to match the current usage in Henry `v0.1.3`

Example:

```python
from henry.api import Henry

h = Henry(**config)
>>> h.*
h.analyze( h.analyzer h.args     h.api   h.pulse    h.scanner    h.to_df(   h.vacuum(
```

See more examples [here](https://github.com/iamaziz/henry/blob/master/PYTHONAPI_DOCS.md#example-usage).
