### PR TITLE
Jorickvd hoeven update henry to work with the latest looker updates

### DIFF
--- a/henry/cli.py
+++ b/henry/cli.py
@@ -8,7 +8,7 @@ from henry.commands import analyze, pulse, vacuum
 from henry.modules import fetcher
 
 
-def main():
+def main() -> None:
     parser = setup_cli()
     user_input = parse_input(parser)
 
@@ -19,16 +19,16 @@ def main():
     elif user_input.command == "vacuum":
         vacuum.Vacuum.run(user_input)
     else:
-        parser.error()
+        parser.error("Unable to parse cli commands")
 
 
-def setup_cli():
+def setup_cli() -> argparse.ArgumentParser:
     parser = create_parser()
     setup_subparsers(parser)
     return parser
 
 
-def create_parser():
+def create_parser() -> argparse.ArgumentParser:
     help_file = os.path.join(os.path.dirname(henry.__file__), ".support_files/help.rtf")
     with open(help_file, "r", encoding="unicode_escape") as myfile:
         description = myfile.read()
@@ -49,14 +49,14 @@ def create_parser():
     return parser
 
 
-def setup_subparsers(parser):
+def setup_subparsers(parser: argparse.ArgumentParser) -> None:
     subparsers = parser.add_subparsers(dest="command", help=argparse.SUPPRESS)
     setup_pulse_subparser(subparsers)
     setup_analyze_subparser(subparsers)
     setup_vacuum_subparser(subparsers)
 
 
-def setup_pulse_subparser(subparsers):
+def setup_pulse_subparser(subparsers: argparse._SubParsersAction) -> None:
     pulse_parser = subparsers.add_parser(
         "pulse", help="pulse help", usage="henry pulse [global options]"
     )
@@ -72,7 +72,7 @@ def setup_pulse_subparser(subparsers):
     )
 
 
-def setup_analyze_subparser(subparsers):
+def setup_analyze_subparser(subparsers: argparse._SubParsersAction) -> None:
     analyze_parser = subparsers.add_parser(
         "analyze", help="analyze help", usage="henry analyze"
     )
@@ -165,7 +165,7 @@ def setup_analyze_subparser(subparsers):
     add_common_arguments(analyze_explores)
 
 
-def setup_vacuum_subparser(subparsers):
+def setup_vacuum_subparser(subparsers: argparse._SubParsersAction) -> None:
     vacuum_parser = subparsers.add_parser(
         "vacuum", help="vacuum help", usage="henry vacuum"
     )
@@ -221,7 +221,7 @@ def setup_vacuum_subparser(subparsers):
     add_common_arguments(vacuum_explores)
 
 
-def add_common_arguments(parser: argparse.ArgumentParser):
+def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--save",
         action="store_true",
@@ -237,7 +237,7 @@ def add_common_arguments(parser: argparse.ArgumentParser):
     parser.add_argument("--section", type=str, default="Looker", help=argparse.SUPPRESS)
 
 
-def parse_input(parser: argparse.ArgumentParser):
+def parse_input(parser: argparse.ArgumentParser) -> fetcher.Input:
     args = vars(parser.parse_args())
     return fetcher.Input(**args)
 

--- a/henry/modules/fetcher.py
+++ b/henry/modules/fetcher.py
@@ -124,14 +124,14 @@ class Fetcher:
         resp = self.sdk.run_inline_query(
             "json",
             models.WriteQuery(
-                model="i__looker",
+                model="system__activity",
                 view="history",
                 fields=["history.query_run_count, query.model"],
                 filters={
                     "history.created_date": self.timeframe,
                     "query.model": "-system^_^_activity, -i^_^_looker",
                     "history.query_run_count": ">0",
-                    "user.dev_mode": "No",
+                    "user.dev_branch_name": "NULL",
                 },
                 limit="5000",
             ),
@@ -177,7 +177,7 @@ class Fetcher:
         resp = self.sdk.run_inline_query(
             "json",
             models.WriteQuery(
-                model="i__looker",
+                model="system__activity",
                 view="history",
                 fields=["query.view", "history.query_run_count"],
                 filters={
@@ -225,13 +225,13 @@ class Fetcher:
         resp = self.sdk.run_inline_query(
             "json",
             models.WriteQuery(
-                model="i__looker",
+                model="system__activity",
                 view="history",
                 fields=[
                     "query.model",
                     "query.view",
                     "query.formatted_fields",
-                    "query.formatted_filters",
+                    "query.filters",
                     "history.query_run_count",
                 ],
                 filters={
@@ -263,7 +263,7 @@ class Fetcher:
             # and a dimension/measure, it's listed in both query.formatted_fields
             # and query.formatted_filters. The recorded variable keeps track of
             # this, so that no double counting occurs.
-            filters = row["query.formatted_filters"]
+            filters = row["query.filters"]
             if filters:
                 parsed_filters = re.findall(r"(\w+\.\w+)+", filters)
                 for f in parsed_filters:


### PR DESCRIPTION
Problem Statement
Henry has been having two large issues making it difficult to use:

The Pulse command is failing because of an issue in the Looker SDK with the try_connection command.
The queries were running against the i__looker explore which seems to be getting deprecated or seems to be inaccessible to users who aren't admins.
These two problems impact Henry's ability to run and make it difficult to use. We need to fix these so that people can continue to use Henry to administer their Looker instances.

Proposed solution
Pulse command not working:

Given that the reason why the pulse command isn't working is because of the deprecation of the i__looker explore and the fact that the sdk try_connection is broken, we need to catch the exception generated by the sdk and update the queries to use the system_activity explore instead of the i__looker explore.
Analyze queries not working:

i__looker is an explore that is either deprecated or limited to admins, given that generally not all users are admins we should update to use the system_activity explore and update the fields that are used so that we can leverage this explore. An added benefit is that the system_activity explore (on a sample of 1 instance) runs much faster than i__looker.