### PR TITLE
Fix: Updating get_used_explores method in fetcher.py 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@looker-open-source/cloud-looker-devrel


### PR DESCRIPTION
**Problem**
- The fields defined in the WriteQuery section of the `get_used_explores` has a typographic error resulting in this error:

```cli
{"message":"Invalid filter: history.workspace_id","documentation_url":"https://cloud.google.com/looker/docs/r/err/4.0/400/post/queries/run/:result_format"}
```

**Fix:**
- Separate the filter fields correctly