### PR TITLE
Update fetcher.py

### DIFF
--- a/henry/modules/fetcher.py
+++ b/henry/modules/fetcher.py
@@ -133,7 +133,7 @@ class Fetcher:
                     "history.query_run_count": ">0",
                     "user.dev_branch_name": "NULL",
                 },
-                limit="5000",
+                limit="-1",
             ),
         )
         _results: MutableSequence[Dict[str, int]] = json.loads(resp)
@@ -187,7 +187,7 @@ class Fetcher:
                     "query.view": explore,
                     "user.dev_branch_name": "NULL",
                 },
-                limit="5000",
+                limit="-1",
             ),
         )
         _results: MutableSequence[Dict[str, int]] = json.loads(resp)
@@ -241,7 +241,7 @@ class Fetcher:
                     "query.formatted_fields": "-NULL",
                     "history.workspace_id": "production",
                 },
-                limit="5000",
+                limit="-1",
             ),
         )
         data = json.loads(resp)


### PR DESCRIPTION
Removing the 5k row limit response for the sys activity api calls. Replaced with -1 which will pull back all results thus providing more accurate results.